### PR TITLE
Take into account Excon response time

### DIFF
--- a/lib/pvb/instrumentation/excon/request.rb
+++ b/lib/pvb/instrumentation/excon/request.rb
@@ -22,7 +22,8 @@ module PVB # :nodoc:
         end
 
         def total_time
-          PVB::Instrumentation.custom_log_items[category].to_i + event.duration
+          current_time = PVB::Instrumentation.custom_log_items.fetch(category, 0)
+          current_time + event.duration
         end
 
         def instrument_request

--- a/lib/pvb/instrumentation/excon/response.rb
+++ b/lib/pvb/instrumentation/excon/response.rb
@@ -6,7 +6,21 @@ module PVB # :nodoc:
         include Instrument
 
         def process
-          # no-op
+          instrument_response
+        end
+
+        private
+
+        def category
+          event.payload[:category] || event.name
+        end
+
+        def total_time
+          PVB::Instrumentation.custom_log_items[category] + event.duration
+        end
+
+        def instrument_response
+          PVB::Instrumentation.append_to_log(category => total_time)
         end
       end
     end

--- a/lib/pvb/instrumentation/version.rb
+++ b/lib/pvb/instrumentation/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module PVB
   class Instrumentation
-    VERSION = '0.1.0'
+    VERSION = '0.1.1'
   end
 end

--- a/spec/pvb/instrumentation/excon/response_spec.rb
+++ b/spec/pvb/instrumentation/excon/response_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe PVB::Instrumentation::Excon::Response do
+  let(:category)   { 'category_name' }
+
+  let(:event_name) { described_class.name }
+  let(:nowish)     { Time.now }
+  let(:start)      { nowish }
+  let(:finish)     { nowish + 0.5001 }
+  let(:setup_proc) { proc {|event| } }
+  let(:payload)    {
+    { method: :get, path: '/some/path', category: category }
+  }
+
+  let(:event)      { ActiveSupport::Notifications::Event.new(event_name, start, finish, '_id', payload) }
+
+  subject { described_class.new(event, &setup_proc) }
+
+  it 'calls the setup proc' do
+    expect { |b| described_class.new(event, &b) }.to yield_control
+  end
+
+  context 'with a previous time recorded' do
+    before do |ex|
+      PVB::Instrumentation.append_to_log(category => 1500.2)
+    end
+
+    it 'appends the response time to the total time' do
+      subject.process
+      expect(PVB::Instrumentation.custom_log_items).to include(category => 2000.3)
+    end
+  end
+end


### PR DESCRIPTION
We were measuring only the Excon request time, which if I understand correctly
is the time taken to send the request to the server, it does not include the
time it takes to read the response back from the socket.

This could explain why we've seen very small request times since the request
happens with a persistent connection.

It also fixes the issue of adding integers and floats together.