### PR TITLE
Add HTTP URI to gemspec

### DIFF
--- a/lib/pvb/instrumentation/version.rb
+++ b/lib/pvb/instrumentation/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module PVB
   class Instrumentation
-    VERSION = '1.0.0'
+    VERSION = '1.0.1'
   end
 end

--- a/pvb-instrumentation.gemspec
+++ b/pvb-instrumentation.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = 'Provide instrumentation for HTTP Clients used in prison visit booking applications'
   spec.description   = 'Provide instrumentation for HTTP Clients (Excon and Faraday) used in prison visit booking applications'
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.homepage      = "https://github.com/ministryofjustice/pvb-instrumentation"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.


### PR DESCRIPTION
Gemspec error being thrown as valid HTTP URL missing for spec.homepage
and this prevents bundler running